### PR TITLE
RES-359: Only show share URL when applicable

### DIFF
--- a/source/pages/help.ts
+++ b/source/pages/help.ts
@@ -166,6 +166,9 @@ async function init () {
   if (resolverInfo.isp.name.toLowerCase() !== 'cloudflare') {
     setupSection.classList.remove('help-initial-hidden')
   }
+
+  // Show share URL
+  document.querySelector('.debug-url-section').classList.remove('hidden')
 }
 
 if (document.readyState === 'loading') {

--- a/source/pages/help.ts
+++ b/source/pages/help.ts
@@ -168,7 +168,10 @@ async function init () {
   }
 
   // Show share URL
-  document.querySelector('.debug-url-section').classList.remove('hidden')
+  const debugURLSection = <HTMLElement>document.querySelector('.debug-url-section')!
+  if (debugURLSection) {
+    debugURLSection.classList.remove('hidden')
+  }
 }
 
 if (document.readyState === 'loading') {

--- a/source/pages/partials/help.pug
+++ b/source/pages/partials/help.pug
@@ -6,7 +6,7 @@ section(data-section="help")
     h2.description Connection Information
 
   .connection-info
-    div.debug-url-section
+    div.debug-url-section.hidden
       h5.header Please include this URL when you create a post in the community forum.
       textarea.copy-url-area(readonly,data-ref="shareUrl")
       div.footer(data-ref="shareUrlMessage") Click to copy

--- a/source/styles/help.styl
+++ b/source/styles/help.styl
@@ -89,6 +89,8 @@ section[data-section="help"]
     font-family var(--monospace-fonts)
 
   .debug-url-section
+    &.hidden
+      display: none
     .header
       margin 0
     .footer


### PR DESCRIPTION
This only makes the "share URL" section visible once all the data has been fetched, so that the user cannot copy incomplete links.

Also, the section is hidden on shared URL view (data extracted from hash).