### PR TITLE
RES-370 - Do not preload videos in setup section

### DIFF
--- a/source/pages/partials/setup.pug
+++ b/source/pages/partials/setup.pug
@@ -39,13 +39,10 @@ section#setup-instructions.help-initial-hidden(data-section="setup" data-ref="se
         +render(instruction)
 
     stream(
-      style="font-size: 16px; width: 616px; max-width: 100%;"
-      id="b95943849d53350130ba22d039fa6faf"
-      site="cloudflare.com")
-    script(
-      data-cfasync="false"
-      defer
-      src="https://embed.cloudflarestream.com/embed/we4g.fla9.latest.js?video=b95943849d53350130ba22d039fa6faf")
+      style="width: 616px; max-width: 100%;"
+      src="b95943849d53350130ba22d039fa6faf"
+      controls
+    )
 
   .instructions(data-platform="iphone")
     ol
@@ -53,13 +50,10 @@ section#setup-instructions.help-initial-hidden(data-section="setup" data-ref="se
         +render(instruction)
 
     stream(
-      style="font-size: 16px; width: 616px; max-width: 100%;"
-      id="ddf07732bc76fc854d4b1879eea2c517"
-      site="cloudflare.com")
-    script(
-      data-cfasync="false"
-      defer
-      src="https://embed.cloudflarestream.com/embed/we4g.fla9.latest.js?video=ddf07732bc76fc854d4b1879eea2c517")
+      style="width: 616px; max-width: 100%;"
+      src="ddf07732bc76fc854d4b1879eea2c517"
+      controls
+    )
 
   .instructions(data-platform="linux")
     p!=htmlWebpackPlugin.options.t('instructions').linux.notice
@@ -74,13 +68,10 @@ section#setup-instructions.help-initial-hidden(data-section="setup" data-ref="se
         +render(instruction)
 
     stream(
-      style="font-size: 16px; width: 616px; max-width: 100%;"
-      id="92b27227d737a866adc8b0572cf0db89"
-      site="cloudflare.com")
-    script(
-      data-cfasync="false"
-      defer
-      src="https://embed.cloudflarestream.com/embed/we4g.fla9.latest.js?video=92b27227d737a866adc8b0572cf0db89")
+      style="width: 616px; max-width: 100%;"
+      src="92b27227d737a866adc8b0572cf0db89"
+      controls
+    )
 
   .instructions(data-platform="android")
     .message
@@ -90,13 +81,10 @@ section#setup-instructions.help-initial-hidden(data-section="setup" data-ref="se
         +render(instruction)
 
     stream(
-      style="font-size: 16px; width: 616px; max-width: 100%;"
-      id="62dceb0d5905f0c98a895d21409d6247"
-      site="cloudflare.com")
-    script(
-      data-cfasync="false"
-      defer
-      src="https://embed.cloudflarestream.com/embed/we4g.fla9.latest.js?video=62dceb0d5905f0c98a895d21409d6247")
+      style="width: 616px; max-width: 100%;"
+      src="62dceb0d5905f0c98a895d21409d6247"
+      controls
+    )
 
   .instructions(data-platform="router")
     .message.center
@@ -108,3 +96,10 @@ section#setup-instructions.help-initial-hidden(data-section="setup" data-ref="se
 
   //- p.additional-content.debug-link!=htmlWebpackPlugin.options.t('instructions').debug
   p.additional-content.questions-link!=htmlWebpackPlugin.options.t('instructions').questions
+
+  script(
+    data-cfasync="false"
+    defer
+    type="text/javascript"
+    src="https://embed.cloudflarestream.com/embed/r4xu.fla9.latest.js"
+  )


### PR DESCRIPTION
Convert streams in the setup section to use the new embed API and not preload the videos.
This decreases the page size by about 10x (~15MB to ~1.5MB).