### PR TITLE
fix success message text color

### DIFF
--- a/source/styles/purge-cache.styl
+++ b/source/styles/purge-cache.styl
@@ -121,7 +121,7 @@ body.purge-cache-page
           background-color var(--brand-accent-light-green)
           color var(--brand-accent-dark-green)
           border 1px solid var(--brand-accent-mid-green)
-          color white
+          color 1px solid var(--brand-accent-dark-green)
 
         &.error
           background-color var(--brand-accent-light-red)


### PR DESCRIPTION

<img width="570" alt="screen shot 2018-08-03 at 9 52 15 am" src="https://user-images.githubusercontent.com/5771916/43655143-9f837700-9702-11e8-8ced-acc8c161d9fb.png">

text color now changed to black.