### PR TITLE
Differentiate Android versions and setup instructions for Pie

### DIFF
--- a/source/pages/partials/setup.pug
+++ b/source/pages/partials/setup.pug
@@ -74,6 +74,12 @@ section#setup-instructions.help-initial-hidden(data-section="setup" data-ref="se
     )
 
   .instructions(data-platform="android")
+    h3!=htmlWebpackPlugin.options.t('instructions').android9.version
+    ol
+      each instruction in htmlWebpackPlugin.options.t('instructions').android9.steps
+        +render(instruction)
+
+    h3!=htmlWebpackPlugin.options.t('instructions').android.version
     .message
       p.collapsed-margins.message-content!=htmlWebpackPlugin.options.t('instructions').android.message
     ol

--- a/source/utilities/i18n/lang/de-DE.json
+++ b/source/utilities/i18n/lang/de-DE.json
@@ -142,6 +142,15 @@
         {"tag": "li", "content": "Sie sind fertig! Ihr Gerät hat jetzt einen schnelleren, privaten DNS-Server ✌️✌️"}
       ]
     },
+    "android9": {
+      "message": "Null",
+      "steps": [
+        {"tag": "li", "content": "Go to <strong>Settings</strong> → <strong>Network & internet</strong> → <strong>Advanced</strong> → <strong>Private DNS</strong>."},
+        {"tag": "li", "content": "Select the </strong>Private DNS provider hostname</strong> option."},
+        {"tag": "li", "content": "Enter <strong class=\"code\">1dot1dot1dot1.cloudflare-dns.com</strong> and hit <strong>Save</strong>."},
+        {"tag": "li", "content": "You’re all set! Your device now has faster, more private DNS servers ✌️✌️"}
+      ]
+    },
     "router": {
       "message": "Ihre Router-Konfiguration kann variieren. Finden Sie im Handbuch weitere Informationen.",
       "steps": [

--- a/source/utilities/i18n/lang/en-US.json
+++ b/source/utilities/i18n/lang/en-US.json
@@ -127,6 +127,7 @@
       ]
     },
     "android": {
+      "version": "Previous Versions",
       "message": "Note that Android requires a static IP to use custom DNS servers. This setup requires additional setup on your router, affecting your network’s strategy for adding new devices to the network. We recommend configuring your <button class=\"inline-button\" type=\"button\" onclick=\"chooseInstructions('router')\">router’s DNS</button> instead. This will give all devices on your network the full speed and privacy benefits of 1.1.1.1 DNS.",
       "steps": [
         {"tag": "li", "content": "From your Android’s app list, open the <strong>Settings</strong> app."},
@@ -140,6 +141,16 @@
         {"tag": "li", "content": "In the <strong>DNS 1</strong> field, enter <strong class=\"code\">1.1.1.1</strong>"},
         {"tag": "li", "content": "In the <strong>DNS 2</strong> field, enter <strong class=\"code\">1.0.0.1</strong> (This is for redundancy.)"},
         {"tag": "li", "content": "Tap <strong>Save</strong>."},
+        {"tag": "li", "content": "You’re all set! Your device now has faster, more private DNS servers ✌️✌️"}
+      ]
+    },
+    "android9": {
+      "version": "Android 9 Pie",
+      "message": "Null",
+      "steps": [
+        {"tag": "li", "content": "Go to <strong>Settings → Network & internet → Advanced → Private DNS</strong>."},
+        {"tag": "li", "content": "Select the <strong>Private DNS provider hostname</strong> option."},
+        {"tag": "li", "content": "Enter <strong class=\"code\">1dot1dot1dot1.cloudflare-dns.com</strong> and hit <strong>Save</strong>."},
         {"tag": "li", "content": "You’re all set! Your device now has faster, more private DNS servers ✌️✌️"}
       ]
     },

--- a/source/utilities/i18n/lang/es-ES.json
+++ b/source/utilities/i18n/lang/es-ES.json
@@ -134,6 +134,7 @@
       ]
     },
     "android": {
+      "version": "Previous Versions",
       "message": "Ten en cuenta que Android requiere una dirección IP estática para utilizar servidores DNS personalizados. Esta configuración requiere ajustes adicionales en el router, lo que afecta a la estrategia de la red para añadir nuevos dispositivos a la red. Recomendamos configurar <button class=\"inline-button\" type=\"button\" onclick=\"chooseInstructions('router')\">el DNS de tu router </button>. Esto le proporcionará a todos los dispositivos de tu red la velocidad y privacidad completas de 1.1.1.1.",
       "steps": [
         {"tag": "li", "content": "A partir de la lista de aplicaciones de Android, abra la aplicación <strong>Ajustes</strong>."},
@@ -148,6 +149,16 @@
         {"tag": "li", "content": "En el campo <strong>DNS 2</strong>, escribe <strong class=\"code\">1.0.0.1</strong>"},
         {"tag": "li", "content": "Toca <strong>Guardar</strong>."},
         {"tag": "li", "content": "¡Ya está todo listo! Tu dispositivo tiene ahora los servidores DNS más rápidos y privados ✌️✌️"}
+      ]
+    },
+    "android9": {
+      "version": "Android 9 Pie",
+      "message": "Null",
+      "steps": [
+        {"tag": "li", "content": "Go to <strong>Settings</strong> → <strong>Network & internet</strong> → <strong>Advanced</strong> → <strong>Private DNS</strong>."},
+        {"tag": "li", "content": "Select the </strong>Private DNS provider hostname</strong> option."},
+        {"tag": "li", "content": "Enter <strong class=\"code\">1dot1dot1dot1.cloudflare-dns.com</strong> and hit <strong>Save</strong>."},
+        {"tag": "li", "content": "You’re all set! Your device now has faster, more private DNS servers ✌️✌️"}
       ]
     },
     "router": {

--- a/source/utilities/i18n/lang/fr-FR.json
+++ b/source/utilities/i18n/lang/fr-FR.json
@@ -127,6 +127,7 @@
       ]
     },
     "android": {
+      "version": "Previous Versions",
       "message": "Notez qu’Android nécessite une adresse IP statique pour utiliser des serveurs DNS personnalisés. Cette configuration nécessite une configuration supplémentaire sur votre routeur, ce qui affecte la stratégie de votre réseau pour ajouter de nouveaux appareils au réseau. Nous vous recommandons de configurer le <button class=\"inline-button\" type=\"button\" onclick=\"chooseInstructions('router')\">DNS de votre routeur</button> à la place. Cela donnera à tous les appareils de votre réseau les avantages du DNS Cloudflare en termes de performance et confidentialité.",
       "steps": [
         {"tag": "li", "content": "Dans la liste des applications de votre Android, ouvrez l’application <strong>Paramètres</strong> app."},
@@ -141,6 +142,16 @@
         {"tag": "li", "content": "Dans le champ <strong>DNS 2</strong>, entrez <strong class=\"code\">1.0.0.1</strong> (Ceci est pour la redondance.)"},
         {"tag": "li", "content": "Appuyez sur <strong>Enregistrer</strong>."},
         {"tag": "li", "content": "Tout est prêt! Votre appareil dispose désormais de serveurs DNS plus rapides et plus privés ✌️✌️"}
+      ]
+    },
+    "android9": {
+      "version": "Android 9 Pie",
+      "message": "Null",
+      "steps": [
+        {"tag": "li", "content": "Go to <strong>Settings</strong> → <strong>Network & internet</strong> → <strong>Advanced</strong> → <strong>Private DNS</strong>."},
+        {"tag": "li", "content": "Select the </strong>Private DNS provider hostname</strong> option."},
+        {"tag": "li", "content": "Enter <strong class=\"code\">1dot1dot1dot1.cloudflare-dns.com</strong> and hit <strong>Save</strong>."},
+        {"tag": "li", "content": "You’re all set! Your device now has faster, more private DNS servers ✌️✌️"}
       ]
     },
     "router": {

--- a/source/utilities/i18n/lang/ja-JP.json
+++ b/source/utilities/i18n/lang/ja-JP.json
@@ -126,6 +126,7 @@
       ]
     },
     "android": {
+      "version": "Previous Versions",
       "message": "Androidでは、カスタムDNSサーバーを使用するためには静的IPが必要です。このセットアップを行うにはルーターの追加設定が必要です。これにより、ルーターが新しいデバイスを追加するためのネットワークの戦略に影響を与える場合があります。 代わりに、<button class=\"inline-button\" type=\"button\" onclick=\"chooseInstructions('router')\">ルーターのDNS </button>の設定をお勧めします。 これにより、お客様のネットワーク上のすべてのデバイスで、Cloudflare DNSが提供する高速でプライバシー性の高いネット環境が実現します。",
       "steps": [
         {"tag": "li", "content": "Androidのアプリのリストから、<strong>設定 </strong>アプリを開きます。"},
@@ -140,6 +141,16 @@
         {"tag": "li", "content": "<strong>「DNS 2」</strong>フィールドで、<strong class=\"code\">1.0.0.1</strong>を入力してください。（これは、冗長性を確保するためです。）"},
         {"tag": "li", "content": "<strong>「保存」</strong>をタップします。"},
         {"tag": "li", "content": "これで完了です！お使いのデバイスはこれで、より速く、よりプライベートなDNSサーバーに設定されました✌️✌️"}
+      ]
+    },
+    "android9": {
+      "version": "Android 9 Pie",
+      "message": "Null",
+      "steps": [
+        {"tag": "li", "content": "Go to <strong>Settings</strong> → <strong>Network & internet</strong> → <strong>Advanced</strong> → <strong>Private DNS</strong>."},
+        {"tag": "li", "content": "Select the </strong>Private DNS provider hostname</strong> option."},
+        {"tag": "li", "content": "Enter <strong class=\"code\">1dot1dot1dot1.cloudflare-dns.com</strong> and hit <strong>Save</strong>."},
+        {"tag": "li", "content": "You’re all set! Your device now has faster, more private DNS servers ✌️✌️"}
       ]
     },
     "router": {

--- a/source/utilities/i18n/lang/ko-KR.json
+++ b/source/utilities/i18n/lang/ko-KR.json
@@ -126,6 +126,7 @@
       ]
     },
     "android": {
+      "version": "Previous Versions",
       "message": "안드로이드는 수동으로 DNS를 변경하려면 고정 IP가 필요합니다. 이렇게 하면 인터넷 공유기에 추가 설정을 해야 하고 네트워크에 신규 장치를 추가할 때의 설정에 영향을 미칩니다. 대신 <button class=\"inline-button\" type=\"button\" onclick=\"chooseInstructions('router')\">공유기의 DNS 설정</button>을 변경하는 것을 권장 합니다. 이렇게 하면 사용중인 네트워크의 모든 장치에 1.1.1.1 DNS의 속도와 안정성을 제공하게 됩니다.",
       "steps": [
         {"tag": "li", "content": "안드로이드 앱 목록에서 <strong>설정</strong> 앱을 누릅니다."},
@@ -140,6 +141,16 @@
         {"tag": "li", "content": "<strong>DNS 2</strong>필드를 누르고 <strong class=\"code\">1.0.0.1</strong>을 입력합니다(이것은 여분의 설정을 위한 것입니다)."},
         {"tag": "li", "content": "<strong>저장</strong>을 누릅니다."},
         {"tag": "li", "content": "완료되었습니다! 이제 더 빠르고 더 안전한 DNS 서버를 이용할 수 있습니다  ✌️✌️"}
+      ]
+    },
+    "android9": {
+      "version": "Android 9 Pie",
+      "message": "Null",
+      "steps": [
+        {"tag": "li", "content": "Go to <strong>Settings</strong> → <strong>Network & internet</strong> → <strong>Advanced</strong> → <strong>Private DNS</strong>."},
+        {"tag": "li", "content": "Select the </strong>Private DNS provider hostname</strong> option."},
+        {"tag": "li", "content": "Enter <strong class=\"code\">1dot1dot1dot1.cloudflare-dns.com</strong> and hit <strong>Save</strong>."},
+        {"tag": "li", "content": "You’re all set! Your device now has faster, more private DNS servers ✌️✌️"}
       ]
     },
     "router": {

--- a/source/utilities/i18n/lang/nl-NL.json
+++ b/source/utilities/i18n/lang/nl-NL.json
@@ -127,6 +127,7 @@
       ]
     },
     "android": {
+      "version": "Previous Versions",
       "message": "Wees ervan bewust dat Android een statisch IP-adres vereist om niet-standaard DNS-servers te gebruiken. Dit vereist extra instellingen op je router, wat een impact heeft op de manier waarop nieuwe toestellen toegang kunnen krijgen tot het netwerk. We raden je aan om je router zijn <button class=\"inline-button\" type=\"button\" onclick=\"chooseInstructions('router')\">DNS instellingen</button> aan te passen. Dit geeft alle toestellen op je netwerk de snelheid en privacy voordelen van de <strong>1.1.1.1<strong> DNS-servers.",
       "steps": [
         {"tag": "li", "content": "Open de <strong>Instellingen</strong> app."},
@@ -140,6 +141,16 @@
         {"tag": "li", "content": "In het <strong>DNS 2</strong> veld, voer <strong class=\"code\">1.0.0.1</strong> in (Dit is voor extra zekerheid.)"},
         {"tag": "li", "content": "Tik <strong>Opslaan</strong>. aan"},
         {"tag": "li", "content": "Je bent helemaal klaar! Je toestel heeft nu snellere DNS-servers, met een focus op privacy ✌️✌️"}
+      ]
+    },
+    "android9": {
+      "version": "Android 9 Pie",
+      "message": "Null",
+      "steps": [
+        {"tag": "li", "content": "Go to <strong>Settings</strong> → <strong>Network & internet</strong> → <strong>Advanced</strong> → <strong>Private DNS</strong>."},
+        {"tag": "li", "content": "Select the </strong>Private DNS provider hostname</strong> option."},
+        {"tag": "li", "content": "Enter <strong class=\"code\">1dot1dot1dot1.cloudflare-dns.com</strong> and hit <strong>Save</strong>."},
+        {"tag": "li", "content": "You’re all set! Your device now has faster, more private DNS servers ✌️✌️"}
       ]
     },
     "router": {

--- a/source/utilities/i18n/lang/pt-BR.json
+++ b/source/utilities/i18n/lang/pt-BR.json
@@ -126,6 +126,7 @@
         ]
       },
       "android": {
+        "version": "Previous Versions",
         "message": "Note que dispositivos Android exigem que você use um IP estático para configurar servidores DNS. Isso requer configuração adicional no seu roteador, afetando a estratégia de rede para adicionar novos dispositivos à rede. Nós recomendamos que ao invés disso você configure o <button class=\"inline-button\" type=\"button\" onclick=\"chooseInstructions('router')\">DNS do roteador</button>. Isso vai dar a todos os dispositivos na sua rede a velocidade máxima e benefícios de privacidade do DNS 1.1.1.1.",
         "steps": [
           {"tag": "li", "content": "Na lista de apps do seu Android’s, abra o app <strong>Configurações</strong>."},
@@ -142,6 +143,16 @@
           {"tag": "li", "content": "Pronto! Seu dispositivo agora tem um servidor DNS mais rápido e mais privado ✌️✌️"}
         ]
       },
+      "android9": {
+      "version": "Android 9 Pie",
+      "message": "Null",
+      "steps": [
+        {"tag": "li", "content": "Go to <strong>Settings</strong> → <strong>Network & internet</strong> → <strong>Advanced</strong> → <strong>Private DNS</strong>."},
+        {"tag": "li", "content": "Select the </strong>Private DNS provider hostname</strong> option."},
+        {"tag": "li", "content": "Enter <strong class=\"code\">1dot1dot1dot1.cloudflare-dns.com</strong> and hit <strong>Save</strong>."},
+        {"tag": "li", "content": "You’re all set! Your device now has faster, more private DNS servers ✌️✌️"}
+      ]
+    },
       "router": {
         "message": "A configuração do seu roteador pode variar. Consulte o manual para mais informações.",
         "steps": [

--- a/source/utilities/i18n/lang/tr-TR.json
+++ b/source/utilities/i18n/lang/tr-TR.json
@@ -127,6 +127,7 @@
       ]
     },
     "android": {
+      "version": "Previous Versions",
       "message": "Android üzerinde DNS adresinizi değiştirmek için ağınızda statik IP adresi kullanmanız gerekmektedir. Bu ayar, İnternet router'ınız üzerinde bazı ayarları değiştirmenizi gerektrimektedir. Bu nedenle, <button class=\"inline-button\" type=\"button\" onclick=\"chooseInstructions('router')\">router</button>'ınız üzerinde DNS ayarlarınızı değiştirmenizi tavsiye ederiz.",
       "steps": [
         {"tag": "li", "content": "Android app'lerinizden <strong>ayarlar</strong>ı seçin."},
@@ -141,6 +142,16 @@
         {"tag": "li", "content": "<strong>DNS 2</strong> kısmına, <strong>1.0.0.1</strong> girin. (Yedek olarak.)"},
         {"tag": "li", "content": "<strong>Kaydet</strong>'e basın."},
         {"tag": "li", "content": "Bu kadar! Şimdi cihazınız daha hızlı ve daha güvenli bir DNS servisini kullanıyor ✌️✌️"}
+      ]
+    },
+    "android9": {
+      "version": "Android 9 Pie",
+      "message": "Null",
+      "steps": [
+        {"tag": "li", "content": "Go to <strong>Settings</strong> → <strong>Network & internet</strong> → <strong>Advanced</strong> → <strong>Private DNS</strong>."},
+        {"tag": "li", "content": "Select the </strong>Private DNS provider hostname</strong> option."},
+        {"tag": "li", "content": "Enter <strong class=\"code\">1dot1dot1dot1.cloudflare-dns.com</strong> and hit <strong>Save</strong>."},
+        {"tag": "li", "content": "You’re all set! Your device now has faster, more private DNS servers ✌️✌️"}
       ]
     },
     "router": {

--- a/source/utilities/i18n/lang/zh-Hans.json
+++ b/source/utilities/i18n/lang/zh-Hans.json
@@ -142,6 +142,15 @@
         {"tag": "li", "content": "一切就绪！您设备的 DNS 服务器现在速度更快、私密性更强 ✌️✌️"}
       ]
     },
+    "android9": {
+      "message": "Null",
+      "steps": [
+        {"tag": "li", "content": "Go to <strong>Settings</strong> → <strong>Network & internet</strong> → <strong>Advanced</strong> → <strong>Private DNS</strong>."},
+        {"tag": "li", "content": "Select the </strong>Private DNS provider hostname</strong> option."},
+        {"tag": "li", "content": "Enter <strong class=\"code\">1dot1dot1dot1.cloudflare-dns.com</strong> and hit <strong>Save</strong>."},
+        {"tag": "li", "content": "You’re all set! Your device now has faster, more private DNS servers ✌️✌️"}
+      ]
+    },
     "router": {
       "message": "您的路由器配置可能会有所不同。详情请参阅手册。",
       "steps": [

--- a/source/utilities/i18n/lang/zh-Hant.json
+++ b/source/utilities/i18n/lang/zh-Hant.json
@@ -126,6 +126,7 @@
       ]
     },
     "android": {
+      "version": "Previous Versions",
       "message": "請注意，Android 需要一個靜態 IP 以使用自定義的 DNS 服務器。 此設置需要在路由器上進行額外設置，會影響到您增加新設備到網絡的策略。 我們建議配置您<button class=\"inline-button\" type=\"button\" onclick=\"chooseInstructions('router')\">router 的 DNS </button>。 這會給您網絡上所有設備的 Cloudflare DNS 全速且具私密性的好處。",
       "steps": [
         {"tag": "li", "content": "這會給您網絡上所有設備的 Cloudflare DNS 全速且具私密性的好處。"},
@@ -140,6 +141,16 @@
         {"tag": "li", "content": "在<strong> [DNS 2] </strong> 領域中，輸入<strong class=\"code\">1.0.0.1</strong>（這是為了實現冗餘。）"},
         {"tag": "li", "content": "點擊<strong> [保存] </strong>。"},
         {"tag": "li", "content": "一切就緒！ 您的設備現在具有更快、更私密的 DNS 服務器 ✌️✌️"}
+      ]
+    },
+    "android9": {
+      "version": "Android 9 Pie",
+      "message": "Null",
+      "steps": [
+        {"tag": "li", "content": "Go to <strong>Settings</strong> → <strong>Network & internet</strong> → <strong>Advanced</strong> → <strong>Private DNS</strong>."},
+        {"tag": "li", "content": "Select the </strong>Private DNS provider hostname</strong> option."},
+        {"tag": "li", "content": "Enter <strong class=\"code\">1dot1dot1dot1.cloudflare-dns.com</strong> and hit <strong>Save</strong>."},
+        {"tag": "li", "content": "You’re all set! Your device now has faster, more private DNS servers ✌️✌️"}
       ]
     },
     "router": {


### PR DESCRIPTION
This adds instructions for configuring 1.1.1.1 with Android 9 Pie by creating a concept of devu=ice "versions" just for Android in the localization files. This lets us visually differentiate between the instructions for different versions of Android.

## TODO
- [ ] Update [developer docs](https://developers.cloudflare.com/1.1.1.1/setting-up-1.1.1.1/android/)
- [ ] Localization
- [ ] Merge into master
- [ ] Push to production

## User-facing changes

### Mobile

![localhost_1111_ pixel 2 xl](https://user-images.githubusercontent.com/778344/44233573-d6ab7900-a169-11e8-8d91-9613bc0bc3f2.png)

### Desktop

![screen shot 2018-08-16 at 3 32 23 pm](https://user-images.githubusercontent.com/778344/44233579-dca15a00-a169-11e8-88ec-84ad7ae933eb.png)
