### PR TITLE
RES-423: Query v6 instances by hostname (to fix Safari cert error)

### DIFF
--- a/source/pages/help.ts
+++ b/source/pages/help.ts
@@ -90,18 +90,15 @@ function readFromShareData() {
   }
 }
 
-const resolverIps: string[] = ['1.1.1.1', '1.0.0.1', '2606:4700:4700::1111', '2606:4700:4700::1001']
-
-const resolverTests = {
+const resolverTests: { [key: string]: string } = {
   isCf: `${uuid}.is-cf.cloudflareresolve.com`,
   isDot: `${uuid}.is-dot.cloudflareresolve.com`,
-  isDoh: `${uuid}.is-doh.cloudflareresolve.com`
-} as { [key: string]: string }
-
-resolverIps.forEach(ip => {
-  const v6 = ip.includes(':')
-  resolverTests[`resolverIp-${ip}`] = `${v6 ? '[' : ''}${ip}${v6 ? ']' : ''}`
-})
+  isDoh: `${uuid}.is-doh.cloudflareresolve.com`,
+  'resolverIp-1.1.1.1': '1.1.1.1',
+  'resolverIp-1.0.0.1': '1.0.0.1',
+  'resolverIp-2606:4700:4700::1111': 'ipv6b.cloudflare-dns.com',
+  'resolverIp-2606:4700:4700::1001': 'ipv6a.cloudflare-dns.com'
+}
 
 async function init () {
   initInstructionPicker()


### PR DESCRIPTION
This PR changes the `resolverTest` calls to use hostnames: 
- `ipv6a.cloudflare-dns.com` (`2606:4700:4700::1001`)
- `ipv6b.cloudflare-dns.com` (`2606:4700:4700::1111`)

instead of direct IPs, to fix Safari cert not found error.

<img width="742" alt="screen shot 2018-08-20 at 11 23 16 am" src="https://user-images.githubusercontent.com/6784226/44359025-871bc480-a46b-11e8-8bb6-65c04acc2ff5.png">
